### PR TITLE
docs: clarify Next.js App Router requirements

### DIFF
--- a/drizzle-orm/src/sqlite-core/README.md
+++ b/drizzle-orm/src/sqlite-core/README.md
@@ -49,27 +49,9 @@ const db = drizzle(sqlite);
 const allUsers = db.select().from(users).all();
 ```
 
-### Using Drizzle ORM in Next.js app router
+### Using Drizzle ORM in Next.js App Router
 
-In order to use Drizzle ORM in the Next.js new app router mode you have to add `better-sqlite3` dependendency to the `experimental.serverComponentsExternalPackages` array in `next.config.js` config file.
-
-Example `next.config.js` should look like this:
-
-```ts
-/** @type {import("next").NextConfig} */
-const config = {
-  reactStrictMode: true,
-  experimental: {
-    appDir: true,
-    serverComponentsExternalPackages: ["better-sqlite3"],
-  },
-}
-export default config
-```
-
-More details about `serverComponentsExternalPackages` can be found in the [Next.js beta docs](https://beta.nextjs.org/docs/api-reference/next-config#servercomponentsexternalpackages).
-
-> **Note**: New next.js beta docs changes frequently so if the link above doesn't work try this one: [Next.js beta docs](https://beta.nextjs.org/docs/api-reference/next-config.js#servercomponentsexternalpackages).
+Next.js' App Router have zero-config support for Drizzle ORM.
 
 ## Connecting to databases
 


### PR DESCRIPTION
As Next.js App Router has been stable since May https://nextjs.org/blog/next-13-4#nextjs-app-router and `better-sqlite3` is handler OOB https://github.com/vercel/next.js/pull/47327

These changes are not necessary anymore.